### PR TITLE
Create API endpoint for admin to be able to add food item

### DIFF
--- a/app/controllers/foodController.js
+++ b/app/controllers/foodController.js
@@ -11,6 +11,36 @@ class FoodControllers {
       },
     );
   }
+
+  addNewfood(request, response) {
+    const { body } = request;
+    const {
+      foodName, categoryId, price, description, image,
+    } = body;
+    const foodNameTrim = foodName.trim('');
+    const categoryIdtrim = categoryId.trim('');
+    const priceTrim = price.trim('');
+    const descriptionTrim = description.trim('');
+    const imageTrim = image.trim('');
+    //  initialize the food object
+    const newFood = {
+      foodId: menu.length + 1,
+      foodName: foodNameTrim,
+      categoryId: categoryIdtrim,
+      price: priceTrim,
+      description: descriptionTrim,
+      image: imageTrim,
+      createdAt: Date(),
+      updatedAt: Date(),
+    };
+
+    menu.push(newFood);
+    return response.status(201).json({
+      success: 'true',
+      message: 'A new food has been added successfully',
+      newFood,
+    });
+  }
 }
 
 const foodController = new FoodControllers();

--- a/app/controllers/orderController.js
+++ b/app/controllers/orderController.js
@@ -124,7 +124,6 @@ class OrderControllers {
         itemIndex = index;
       }
     });
-    console.log(orderStatus);
     if (!orderFound) {
       return response.status(404).json({
         success: 'false',

--- a/app/controllers/userController.js
+++ b/app/controllers/userController.js
@@ -31,7 +31,7 @@ class UserControllers {
       newUser,
     });
   }
-  
+
   //  Controller to login a user
   login(request, response) {
     return response.status(200).json({

--- a/app/middlewares/validateMenuItem.js
+++ b/app/middlewares/validateMenuItem.js
@@ -1,0 +1,73 @@
+
+class MenuMiddleware {
+  checkEmptyfields(request, response, next) {
+    const { body } = request;
+    const {
+      foodName, categoryId, price, description, image,
+    } = body;
+    if (!foodName) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a food name',
+      });
+    } else if (!categoryId) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a category Id',
+      });
+    } else if (!price) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a price for the food item',
+      });
+    } else if (!description) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a description for the food item',
+      });
+    } else if (!image) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please add an image for the food item',
+      });
+    }
+    return next();
+  }
+
+  checkDataFormat(request, response, next) {
+    const { body } = request;
+    const {
+      foodName, categoryId, price, description, image,
+    } = body;
+    if (typeof (foodName) !== 'string') {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a valid food name',
+      });
+    } else if (Number.isNaN(Number(categoryId))) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a valid category Id',
+      });
+    } else if (Number.isNaN(Number(price))) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a valid price',
+      });
+    } else if (typeof (description) !== 'string') {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a valid description',
+      });
+    } else if (typeof (image) !== 'string') {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please provide a valid image',
+      });
+    }
+    return next();
+  }
+}
+
+const menuMiddleware = new MenuMiddleware();
+export default menuMiddleware;

--- a/app/routes/foodRoute.js
+++ b/app/routes/foodRoute.js
@@ -1,9 +1,12 @@
 import express from 'express';
 import foodController from '../controllers/foodController';
+import validateMenuitem from '../middlewares/validateMenuItem';
 
-const { getAllfood } = foodController;
+const { checkEmptyfields, checkDataFormat } = validateMenuitem;
+const { getAllfood, addNewfood } = foodController;
 
 const router = express.Router();
 router.get('/api/v1/menu', getAllfood);
+router.post('/api/v1/menu', checkEmptyfields, checkDataFormat, addNewfood);
 
 export default router;

--- a/app/tests/food.test.js
+++ b/app/tests/food.test.js
@@ -16,4 +16,33 @@ describe('Test suite for food API endpoints', () => {
         });
     });
   });
+
+  describe('POST /api/v1/menu', () => {
+    it('should return status 201 if the new food item was added', (done) => {
+      const foodName = 'shawarman and chicken';
+      const categoryId = '2';
+      const price = '3000';
+      const description = 'Sweet and yummy';
+      const image = 'https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg';
+      request(app)
+        .post('/api/v1/menu')
+        .send({
+          foodName, categoryId, price, description, image,
+        })
+        .end((err, response) => {
+          expect(response.status).to.equal(201);
+          done();
+        });
+    });
+
+    it('should return status 400 if the fields were not filled', (done) => {
+      request(app)
+        .post('/api/v1/menu')
+        .send({})
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
### What does this pull request do?
This pull request creates an API endpoint for the admin to be able to add a new food item

### Description of the Task to be completed?
Admin should be able to add another food item to the menu list, for users to have options to select from

### How should this be manually tested?
Users can test it by:
 - Install git
 - Open up the command line
 - Run `git clone https://github.com/oluwajuwon/Fast-Food-Fast.git` to clone the repository
 - Run `npm install` to install all package dependencies
 - Run `npm run start` to start the app
 - Downloading the app Postman from - https://www.getpostman.com/ and install it
 - Open up and postman and enter the URLs below:
http://localhost:3000/api/v1/menu - using the POST request (select the request
by the left side of the URL bar) to add the new item and fill in the required fields (foodName, categoryId, price, description and image(URL))
 - If it returns the status code 201 and a message that says the food item has been added, with the new food item, then it works fine.


### What are the relevant pivotal tracker stories?
The relevant pivotal story is:

Admin should be able to add a new food item - https://www.pivotaltracker.com/story/show/160878017

