### PR TITLE
Create API endpoint for admin to add a new category of menu items

### DIFF
--- a/app/controllers/foodController.js
+++ b/app/controllers/foodController.js
@@ -7,12 +7,10 @@ class FoodControllers {
     const text = 'SELECT * FROM foods';
     db.query(text, (err, result) => {
       if (result.rows.length === 0) {
-        return response.status(404).json(
-          {
-            success: 'false',
-            message: 'no food item available',
-          },
-        );
+        return response.status(404).json({
+          success: 'false',
+          message: 'no food item available',
+        });
       }
       return response.status(200).json({
         success: 'true',
@@ -30,12 +28,10 @@ class FoodControllers {
     const value = [id];
     db.query(text, value, (err, result) => {
       if (result.rows.length === 0) {
-        return response.status(404).json(
-          {
-            success: 'false',
-            message: `food with ${id} does not exist`,
-          },
-        );
+        return response.status(404).json({
+          success: 'false',
+          message: `food with ${id} does not exist`,
+        });
       }
       return response.status(200).json({
         success: 'true',
@@ -63,21 +59,17 @@ class FoodControllers {
     const text = 'INSERT INTO foods(food_name, category_id, price, description, image, created_at, updated_at) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING *';
     return db.query(text, values, (err, result) => {
       if (err) {
-        return response.status(400).json(
-          {
-            success: 'false',
-            message: 'Cant add food, error connecting to the database',
-            errorMessage: err,
-          },
-        );
+        return response.status(400).json({
+          success: 'false',
+          message: 'Cant add food, error connecting to the database',
+          errorMessage: err,
+        });
       }
-      return response.status(201).json(
-        {
-          success: 'true',
-          message: 'The food item was added successfully',
-          result: result.rows[0],
-        },
-      );
+      return response.status(201).json({
+        success: 'true',
+        message: 'The food item was added successfully',
+        result: result.rows[0],
+      });
     });
   }
 
@@ -151,6 +143,27 @@ class FoodControllers {
           result: result.rows[0],
         },
       );
+    });
+  }
+
+  addNewcategory(request, response) {
+    const { categoryName } = request.body;
+    const categoryNameTrim = categoryName.trim('');
+    const values = [categoryNameTrim];
+    const text = 'INSERT INTO category(category_name) VALUES($1) RETURNING *';
+    return db.query(text, values, (error, result) => {
+      if (error) {
+        return response.status(400).json({
+          success: 'false',
+          message: 'Cant add category, error connecting to the database',
+          errorMessage: error,
+        });
+      }
+      return response.status(201).json({
+        success: 'true',
+        message: 'The category was added successfully',
+        newCategory: result.rows[0],
+      });
     });
   }
 }

--- a/app/middlewares/validateMenuItem.js
+++ b/app/middlewares/validateMenuItem.js
@@ -125,9 +125,47 @@ class MenuMiddleware {
     const value = [id];
     return db.query(text, value, (err, result) => {
       if (result.rows.length === 0) {
-        return response.status(409).json({
+        return response.status(404).json({
           success: 'false',
           message: `Category with ID ${id} does not exist`,
+        });
+      }
+      return next();
+    });
+  }
+
+  checkCategoryfield(request, response, next) {
+    const { categoryName } = request.body;
+    const categoryNameTrim = categoryName.trim('');
+    if (categoryName === undefined) {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please add "categoryName"',
+      });
+    } else if (categoryNameTrim === '') {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a category name',
+      });
+    } else if (typeof (categoryNameTrim) !== 'string') {
+      return response.status(400).json({
+        success: 'false',
+        message: 'Please enter a valid category',
+      });
+    }
+    return next();
+  }
+
+  checkCategoryname(request, response, next) {
+    const { categoryName } = request.body;
+    const categoryNameTrim = categoryName.trim('');
+    const text = 'SELECT * FROM category WHERE category_name = $1';
+    const value = [categoryNameTrim];
+    return db.query(text, value, (err, result) => {
+      if (result.rows.length > 0) {
+        return response.status(409).json({
+          success: 'false',
+          message: `Category ${categoryNameTrim} already exists`,
         });
       }
       return next();

--- a/app/routes/foodRoute.js
+++ b/app/routes/foodRoute.js
@@ -10,21 +10,29 @@ const { checkIfadmin } = verifyUser;
 const { checkToken } = verifyToken;
 
 const {
-  checkEmptyfields, checkDataFormat, checkDataitemFormat, checkFoodname, checkCategory,
+  checkEmptyfields, checkDataFormat, checkDataitemFormat, checkFoodname,
+  checkCategory, checkCategoryfield, checkCategoryname,
 } = validateMenuitem;
 
 const {
-  getAllfood, addNewfood, getFood, updateFood, deleteFood,
+  getAllfood, addNewfood, getFood, updateFood, deleteFood, addNewcategory,
 } = foodController;
 
 const { checkFoodparams } = validateParams;
 
 const router = express.Router();
 router.get('/api/v1/menu', getAllfood);
+
 router.get('/api/v1/menu/:foodId', checkFoodparams, getFood);
+
 router.post('/api/v1/menu', checkToken, checkIfadmin, checkEmptyfields, checkDataFormat,
   checkDataitemFormat, checkFoodname, checkCategory, addNewfood);
+
+router.post('/api/v1/category', checkToken, checkIfadmin, checkCategoryfield,
+  checkCategoryname, addNewcategory);
+
 router.put('/api/v1/menu/:foodId', checkToken, checkIfadmin, checkFoodparams, updateFood);
+
 router.delete('/api/v1/menu/:foodId', checkToken, checkIfadmin, checkFoodparams, deleteFood);
 
 export default router;

--- a/app/tests/food.test.js
+++ b/app/tests/food.test.js
@@ -71,6 +71,130 @@ describe('Test suite for food API endpoints', () => {
         });
     });
 
+    it('should return status 404 if the category id does not exist', (done) => {
+      const foodName = 'Rice and stew';
+      const categoryId = '1000';
+      const price = '3000';
+      const description = 'Sweet and yummy';
+      const image = 'https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg';
+      const createdAt = new Date();
+      const updatedAt = new Date();
+      request(app)
+        .post('/api/v1/menu')
+        .set('x-access-token', adminToken)
+        .send({
+          foodName, categoryId, price, description, image, createdAt, updatedAt,
+        })
+        .end((err, response) => {
+          expect(response.status).to.equal(404);
+          done();
+        });
+    });
+
+    it('should return status 400 if the food name entered is more than 225 characters', (done) => {
+      const foodName = `https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg`;
+      const categoryId = '1';
+      const price = '3000';
+      const description = 'Sweet and yummy';
+      const image = 'https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg';
+      const createdAt = new Date();
+      const updatedAt = new Date();
+      request(app)
+        .post('/api/v1/menu')
+        .set('x-access-token', adminToken)
+        .send({
+          foodName, categoryId, price, description, image, createdAt, updatedAt,
+        })
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should return status 400 if the category Id entered is more than 225 characters', (done) => {
+      const foodName = 'yam and beans';
+      const categoryId = `https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg`;
+      const price = '3000';
+      const description = 'Sweet and yummy';
+      const image = 'https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg';
+      const createdAt = new Date();
+      const updatedAt = new Date();
+      request(app)
+        .post('/api/v1/menu')
+        .set('x-access-token', adminToken)
+        .send({
+          foodName, categoryId, price, description, image, createdAt, updatedAt,
+        })
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should return status 400 if the price entered is more than 225 characters', (done) => {
+      const foodName = 'yam and beans';
+      const categoryId = '1';
+      const price = `https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg`;
+      const description = 'Sweet and yummy';
+      const image = 'https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg';
+      const createdAt = new Date();
+      const updatedAt = new Date();
+      request(app)
+        .post('/api/v1/menu')
+        .set('x-access-token', adminToken)
+        .send({
+          foodName, categoryId, price, description, image, createdAt, updatedAt,
+        })
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should return status 400 if the image url is more than 400 characters', (done) => {
+      const foodName = 'yam and beans';
+      const categoryId = '1';
+      const price = '3000';
+      const description = 'Sweet and yummy';
+      const image = `https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg
+      https://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpghttps://cdn.pixabay.com/photo/2017/03/10/13/49/fast-food-2132863__340.jpg`;
+      const createdAt = new Date();
+      const updatedAt = new Date();
+      request(app)
+        .post('/api/v1/menu')
+        .set('x-access-token', adminToken)
+        .send({
+          foodName, categoryId, price, description, image, createdAt, updatedAt,
+        })
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
+          done();
+        });
+    });
+
     it('should return status 400 if the fields were not filled', (done) => {
       const foodName = '';
       const categoryId = '';
@@ -139,6 +263,44 @@ describe('Test suite for food API endpoints', () => {
         .set('x-access-token', adminToken)
         .end((err, response) => {
           expect(response.status).to.equal(200);
+          done();
+        });
+    });
+  });
+
+  describe('POST /api/v1/category', () => {
+    it('should return status 201 if the new category was added successfully', (done) => {
+      const categoryName = 'Drinks';
+      request(app)
+        .post('/api/v1/category')
+        .set('x-access-token', adminToken)
+        .send({ categoryName })
+        .end((err, response) => {
+          expect(response.status).to.equal(201);
+          done();
+        });
+    });
+
+    it('should return status 409 if the category name already exists', (done) => {
+      const categoryName = 'Drinks';
+      request(app)
+        .post('/api/v1/category')
+        .set('x-access-token', adminToken)
+        .send({ categoryName })
+        .end((err, response) => {
+          expect(response.status).to.equal(409);
+          done();
+        });
+    });
+
+    it('should return status 400 if the new category name was not filled', (done) => {
+      const categoryName = '';
+      request(app)
+        .post('/api/v1/category')
+        .set('x-access-token', adminToken)
+        .send({ categoryName })
+        .end((err, response) => {
+          expect(response.status).to.equal(400);
           done();
         });
     });


### PR DESCRIPTION
### What does this pull request do?
This pull request creates an API endpoint for the admin to be able to add categories for menu items

### Description of the Task to be completed?
Admin should be able to group menu items into categories, hence should be able to add different categories

### How should this be manually tested?
Users can test it by:
 - Install git
 - Open up the command line
 - Run `git clone https://github.com/oluwajuwon/Fast-Food-Fast.git` to clone the repository
 - Run `npm install` to install all package dependencies
 - Run `npm run start` to start the app
 - Downloading the app Postman from - https://www.getpostman.com/ and install it
 - Open up and postman and enter the URLs below:
http://localhost:3000/api/v1/category - using the POST request (select the request
by the left side of the URL bar) to add the new item and fill in the required field (categoryName)
 - If it returns the status code 201 and a message that says the category has been added, with the new category object, then it works fine.


### What are the relevant pivotal tracker stories?
The relevant pivotal story is:

Admin should be able to add a new menu category - https://www.pivotaltracker.com/story/show/161202914

