### PR TITLE
Create feature for admin to decline an order

### DIFF
--- a/app/public/admin/decline-confirmation.html
+++ b/app/public/admin/decline-confirmation.html
@@ -56,16 +56,16 @@
         <div class="innerbox-container">
           <div class="form">
             <h2>Decline confirmation</h2>
-            <p>Please state in the box below the reason for declining</p>
-            <p>reason will be sent to user</p>
+            <p>Please state in the box below the reason for declining this order</p>
+            <p>The reason will be sent to the user</p>
             <form id="decline-confirm">
               <div>
                 <p class="">Reason</p>
-                <textarea></textarea>
+                <textarea id="decline-reason"></textarea>
               </div>
               <br />
               <div class="">
-                <input type="submit" class="btn blue-bg-colour white-text" value="Submit" />
+                <input type="submit" id="submit-decline" class="btn blue-bg-colour white-text" value="Submit" />
               </div>
               <br/>
               <br />
@@ -86,7 +86,7 @@
     </div>
   </footer>
   <script type="text/javascript" src="../assets/js/script.js"></script>
-  <script type="text/javascript" src="../assets/js/redirect.js"></script>
+  <script type="text/javascript" src="../fetch/orders.js"></script>
   <script type="text/javascript" src="../fetch/userPage.js"></script>
 </body>
 

--- a/app/public/fetch/orders.js
+++ b/app/public/fetch/orders.js
@@ -74,6 +74,7 @@ const getOrderHistory = () => {
                     <b>Status: </b>
                     <span> ${order.order_status}</span>
                   </p>
+                  <p>${order.decline_reason}</p>
                 </div>
               </div>
             </div>
@@ -103,73 +104,113 @@ const acceptOrder = () => {
     },
     body: JSON.stringify({ orderStatus: status }),
   }).then(response => response.json())
-    .then((data) => {
-      console.log(data);
+    .then(() => {
       window.location.href = '/admin/accept-order-successful.html';
     });
 };
+
+const declineUserOrder = () => {
+  const urlString = window.location.href;
+  const url = new URL(urlString);
+  const orderId = url.searchParams.get('order_id');
+  const declineText = document.getElementById('decline-reason').value;
+  const status = 'Cancelled';
+  fetch(`https://fast-foodfastapp.herokuapp.com/api/v1/orders/${orderId}`, {
+    method: 'PUT',
+    headers: {
+      Accept: 'application/json, text/plain, */*',
+      'Content-Type': 'application/json',
+      'x-access-token': myToken,
+    },
+    body: JSON.stringify({ orderStatus: status, declineReason: declineText }),
+  }).then(response => response.json())
+    .then(() => {
+      window.alert('Order declined Successfully');
+      window.location.href = '/admin/all-orders.html';
+    });
+};
+
+const btnDeclineorder = document.getElementById('submit-decline');
+if (btnDeclineorder === null) {
+} else {
+  btnDeclineorder.addEventListener('click', (event) => {
+    event.preventDefault();
+    declineUserOrder();
+  });
+}
+
 
 const getSpecificOrder = () => {
   const urlString = window.location.href;
   const url = new URL(urlString);
   const orderId = url.searchParams.get('order_id');
   const specificOrderDiv = document.getElementById('specific-order');
-  fetch(`https://fast-foodfastapp.herokuapp.com/api/v1/orders/${orderId}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-access-token': myToken,
-    },
-  }).then(response => response.json())
-    .then((data) => {
-      const { orderFound } = data;
-      let output = '';
-      // const foodItems = JSON.parse(orderFound.food_items);
-      if (orderFound.order_status === 'New') {
-        output += `
-        <div class="order-details">
-          <p><b>Order ID: </b> ${orderFound.order_id}</p>
-          <p><b>Order date and time: </b>${orderFound.created_at} </p>
-          <h3>Items:</h3>
-          <p><b>food: </b> ${orderFound.food_items[0].food_name}, <b>Quantity: </b> ${orderFound.food_items[0].quantity} </p>
-          <p><b>Amount Paid:</b> &#8358;${orderFound.amount_paid}</p>
-          <h3>Order by: ${orderFound.full_name}</h3>
-          <button class="green-bg white-text">
-            <a id="btn-accept-order" class="white-text">Accept</a>
-          </button>
-          <button class="red-bg-colour white-text">
-            <a onclick="modalPopup()" id="btn-decline-order" class="white-text">Decline</a>
-          </button>
-        </div>
-        `;
-      } else {
-        output += `
-        <div class="order-details">
-          <p><b>Order ID: </b> ${orderFound.order_id}</p>
-          <p><b>Order date and time: </b>${orderFound.created_at} </p>
-          <h3>Items:</h3>
-          <p><b>food: </b> ${orderFound.food_items[0].food_name}, <b>Quantity: </b> ${orderFound.food_items[0].quantity} </p>
-          <p><b>Amount Paid:</b> &#8358;${orderFound.amount_paid}</p>
-          <h3>Order by: ${orderFound.full_name}</h3>
-          <p><b>Status: </b> ${orderFound.order_status}</p>
-        </div>
-        `;
-      }
-      if (specificOrderDiv === null) {
-      } else {
-        document.getElementById('specific-order').innerHTML = output;
-        const btnAccept = document.getElementById('btn-accept-order');
-        if (btnAccept === null) {
+  if (orderId === null) {
+  } else {
+    fetch(`https://fast-foodfastapp.herokuapp.com/api/v1/orders/${orderId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-access-token': myToken,
+      },
+    }).then(response => response.json())
+      .then((data) => {
+        const { orderFound } = data;
+        let output = '';
+        // const foodItems = JSON.parse(orderFound.food_items);
+        if (orderFound.order_status === 'New') {
+          output += `
+          <div class="order-details">
+            <p><b>Order ID: </b> ${orderFound.order_id}</p>
+            <p><b>Order date and time: </b>${orderFound.created_at} </p>
+            <h3>Items:</h3>
+            <p><b>food: </b> ${orderFound.food_items[0].food_name}, <b>Quantity: </b> ${orderFound.food_items[0].quantity} </p>
+            <p><b>Amount Paid:</b> &#8358;${orderFound.amount_paid}</p>
+            <h3>Order by: ${orderFound.full_name}</h3>
+            <button class="green-bg white-text">
+              <a id="btn-accept-order" class="white-text">Accept</a>
+            </button>
+            <button class="red-bg-colour white-text">
+              <a id="btn-decline-order" class="white-text">Decline</a>
+            </button>
+          </div>
+          `;
         } else {
-          btnAccept.addEventListener('click', () => {
-            const result = window.confirm('Do you really want to accept this order?');
-            if (result === true) {
-              acceptOrder();
-            }
-          });
+          output += `
+          <div class="order-details">
+            <p><b>Order ID: </b> ${orderFound.order_id}</p>
+            <p><b>Order date and time: </b>${orderFound.created_at} </p>
+            <h3>Items:</h3>
+            <p><b>food: </b> ${orderFound.food_items[0].food_name}, <b>Quantity: </b> ${orderFound.food_items[0].quantity} </p>
+            <p><b>Amount Paid:</b> &#8358;${orderFound.amount_paid}</p>
+            <h3>Order by: ${orderFound.full_name}</h3>
+            <p><b>Status: </b> ${orderFound.order_status}</p>
+          </div>
+          `;
         }
-      }
-    });
+        if (specificOrderDiv === null) {
+        } else {
+          document.getElementById('specific-order').innerHTML = output;
+          const btnAccept = document.getElementById('btn-accept-order');
+          const declineOrder = document.getElementById('btn-decline-order');
+          if (btnAccept === null) {
+          } else {
+            btnAccept.addEventListener('click', () => {
+              const acceptConfirm = window.confirm('Do you really want to accept this order?');
+              if (acceptConfirm === true) {
+                acceptOrder();
+              }
+            });
+            declineOrder.addEventListener('click', () => {
+              const declineConfirm = window.confirm('Do you really want to decline this order?');
+              if (declineConfirm === true) {
+                window.location.href = `/admin/decline-confirmation.html?order_id=${orderFound.order_id}`;
+              }
+            });
+          }
+        }
+      });
+  }
 };
 
 


### PR DESCRIPTION
### What does this pull request do?
This pull request creates a feature for the admin user to accept new orders

### Description of the Task to be completed?
Admin should be able to accept new orders that have being placed by customers, so that the orders can be processed 

### How should this be manually tested?
Users can test it by:
 - Install git
 - Open up the command line
 - Run `git clone https://github.com/oluwajuwon/Fast-Food-Fast.git` to clone the repository
 - Run `npm install` to install all package dependencies
 - Run `npm run start` to start the app
 - Visit http://localhost:3000/login.html to login as admin with the admin credentials
 - Visit http://localhost:3000/admin/all-orders.html
 - Click on "view" on the order of choice to see the details 
    - It should show the details of the order selected on a different page.
    - If the order is new the admin should see a button to decline the order
    - When the admin clicks on 'decline', the app should prompt the admin to confirm the decline
    - When the admin selects "ok", it should redirect the admin to a new page to enter the reason for the declination.
    - When the decline is successful, an alert should pop up  to notify the admin

### What are the relevant pivotal tracker stories?
The relevant pivotal story is:
Admin should be able to decline an order - https://www.pivotaltracker.com/story/show/161233033


### Screenshots
![accept-decline](https://user-images.githubusercontent.com/29441898/47254767-56054380-d45e-11e8-8d63-f47a3cb4cb2d.PNG)
![decline-reason](https://user-images.githubusercontent.com/29441898/47257860-2caedc80-d48b-11e8-8dbe-04c49224ef12.PNG)



